### PR TITLE
Don't generate thumbnail for video's (fixes #26)

### DIFF
--- a/src/models/SitemapTemplate.php
+++ b/src/models/SitemapTemplate.php
@@ -351,9 +351,6 @@ class SitemapTemplate extends FrontendTemplate implements SitemapInterface
                     $lines[] = '      <video:content_loc>';
                     $lines[] = '        '.$asset->getUrl();
                     $lines[] = '      </video:content_loc>';
-                    $lines[] = '      <video:thumbnail_loc>';
-                    $lines[] = '        '.$asset->getThumbUrl(320);
-                    $lines[] = '      </video:thumbnail_loc>';
                     // Handle the dynamic field => property mappings
                     foreach ($metaBundle->metaSitemapVars->sitemapVideoFieldMap as $row) {
                         $fieldName = $row['field'] ?? '';


### PR DESCRIPTION
Maybe you could check if your transcoder plugin is installed and then generate a thumbnail that way? This is at least a temporary fix