### PR TITLE
Specify `rel="noopener"` for external links.

### DIFF
--- a/src/templates/_includes/facebookPreview.twig
+++ b/src/templates/_includes/facebookPreview.twig
@@ -12,7 +12,7 @@ set previewFacebook = seomatic.site.facebookAppId |length or seomatic.site.faceb
         {% if previewFacebook %}
             <div class="Facebook-container">
                 <div class="">
-                    <a href="{{ canonicalArray.href ?? siteUrl("/") }}" target="_blank">
+                    <a href="{{ canonicalArray.href ?? siteUrl("/") }}" rel="noopener" target="_blank">
                         <div class="Facebook-image-wrap">
                             <div id="facebook-post-image" class="Facebook-post-image" style="width:470px;height:246px;">
                             </div>
@@ -22,7 +22,7 @@ set previewFacebook = seomatic.site.facebookAppId |length or seomatic.site.faceb
                 <div class="facebook-text-wrap">
                     <div class="Facebook-text-container">
                         <div class="Facebook-headline">
-                            <a class="Facebook-link" href="{{ canonicalArray.href ?? siteUrl("/") }}" target="_blank">{{ (ogTitleArray.content ?? "") |raw }}</a>
+                            <a class="Facebook-link" href="{{ canonicalArray.href ?? siteUrl("/") }}" rel="noopener" target="_blank">{{ (ogTitleArray.content ?? "") |raw }}</a>
                         </div>
                         <div class="Facebook-text">
                             {{ (ogDescriptionArray.content ?? "") |raw }}

--- a/src/templates/_includes/googlePreview.twig
+++ b/src/templates/_includes/googlePreview.twig
@@ -7,7 +7,7 @@
         <div class="googleWrapper">
             <div class="rc" data-hveid="27">
                 <h3 class="googleDisplay">
-                    <a class="googleDisplay" href="{{ canonicalArray.href ?? siteUrl("/") }}" target="_blank">{{ (titleArray.title ?? "") |raw }}</a>
+                    <a class="googleDisplay" href="{{ canonicalArray.href ?? siteUrl("/") }}" rel="noopener" target="_blank">{{ (titleArray.title ?? "") |raw }}</a>
                 </h3>
                 <div class="googleDisplay1">
                     <div>

--- a/src/templates/_includes/twitterPreview.twig
+++ b/src/templates/_includes/twitterPreview.twig
@@ -12,7 +12,7 @@
             {% endif %}
             <div class="TwitterCardsGrid{% if lg %} TwitterCardsGrid-Large{% endif %}">
                 <div class="TwitterCardGrid-col{% if lg %} TwitterCardGrid-col-Large{% endif %}">
-                    <a class="TwitterCard-container{% if lg %} TwitterCard-container-Large{% endif %}" href="{{ canonicalArray.href ?? siteUrl("/") }}" target="_blank">
+                    <a class="TwitterCard-container{% if lg %} TwitterCard-container-Large{% endif %}" href="{{ canonicalArray.href ?? siteUrl("/") }}" rel="noopener" target="_blank">
                         <div class="TwitterCard-summary-image{% if lg %} TwitterCard-summary-image-Large{% endif %}">
                             <div class="TwitterCard-image-container{% if lg %} TwitterCard-image-container-Large{% endif %}">
                                 <div id="twitter-card-image" class="TwitterCard-image-wrapper{% if lg %} TwitterCard-image-wrapper-Large{% endif %}">

--- a/src/templates/settings/_includes/mainEntityOfPage-partial.twig
+++ b/src/templates/settings/_includes/mainEntityOfPage-partial.twig
@@ -68,7 +68,7 @@
         var selectValue = $('#'+siteSpecificTypeId + ' option:selected').text() || $('#'+siteSubTypeId + ' option:selected').text() || $('#'+siteTypeId + ' option:selected').text();
         // Remove any whitepsace, including encoded &nbsp; characters
         selectValue = selectValue.replace(/\s/g, '');
-        $('.seomaticSchemaInfo').html("<a href='http://schema.org/" + selectValue + "' target='_blank'>" + selectValue + " info...</a>");
+        $('.seomaticSchemaInfo').html("<a href='http://schema.org/" + selectValue + "' rel='noopener' target='_blank'>" + selectValue + " info...</a>");
     }
     
     // Initially hide all of the meta panes

--- a/src/templates/settings/_includes/tab-humans.twig
+++ b/src/templates/settings/_includes/tab-humans.twig
@@ -3,7 +3,7 @@
 
 <div class="flex">
     <div class="flex-grow"></div>
-    <a href="{{ siteUrl("/humans.txt") }}" class="btn livepreviewbtn" target="_blank">{{ 'View humans.txt'|t("seomatic") }}</a>
+    <a href="{{ siteUrl("/humans.txt") }}" class="btn livepreviewbtn" rel="noopener" target="_blank">{{ 'View humans.txt'|t("seomatic") }}</a>
 </div>
 
 {% namespace "humansTemplate" %}

--- a/src/templates/settings/_includes/tab-robots.twig
+++ b/src/templates/settings/_includes/tab-robots.twig
@@ -3,7 +3,7 @@
 
 <div class="flex">
     <div class="flex-grow"></div>
-    <a href="{{ siteUrl("/robots.txt") }}" class="btn livepreviewbtn" target="_blank">{{ 'View robots.txt'|t("seomatic") }}</a>
+    <a href="{{ siteUrl("/robots.txt") }}" class="btn livepreviewbtn" rel="noopener" target="_blank">{{ 'View robots.txt'|t("seomatic") }}</a>
 </div>
 
 {% namespace "robotsTemplate" %}

--- a/src/templates/settings/_includes/tab-sitemap.twig
+++ b/src/templates/settings/_includes/tab-sitemap.twig
@@ -4,8 +4,8 @@
 {% if pageContext != "field" %}
 <div class="flex">
     <div class="flex-grow"></div>
-    <a href="{{ seomatic.helper.sitemapIndexForSiteId(currentSiteId) }}" class="btn livepreviewbtn" target="_blank">{{ 'View Sitemap Index'|t("seomatic") }}</a>
-    <a href="{{ seomatic.helper.sitemapUrlForBundle(currentSourceBundleType, currentSourceHandle, currentSiteId) }}" class="btn livepreviewbtn" target="_blank">{{ "View #{currentSourceBundleType |capitalize} Sitemap"|t("seomatic") }}</a>
+    <a href="{{ seomatic.helper.sitemapIndexForSiteId(currentSiteId) }}" class="btn livepreviewbtn" rel="noopener" target="_blank">{{ 'View Sitemap Index'|t("seomatic") }}</a>
+    <a href="{{ seomatic.helper.sitemapUrlForBundle(currentSourceBundleType, currentSourceHandle, currentSiteId) }}" class="btn livepreviewbtn" rel="noopener" target="_blank">{{ "View #{currentSourceBundleType |capitalize} Sitemap"|t("seomatic") }}</a>
 </div>
 {% endif %}
 


### PR DESCRIPTION
See the following links for the reasoning:

https://mathiasbynens.github.io/rel-noopener/
https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/