### PR TITLE
Fixed namespaces and custom sitemap event triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ use nystudio107\seomatic\events\RegisterSitemapUrlsEvent;
 use nystudio107\seomatic\models\SitemapCustomTemplate;
 use yii\base\Event;
 Event::on(SitemapCustomTemplate::class, SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, function(RegisterSitemapUrlsEvent $e) {
-$e->sitemapUrls[] => [
+$e->sitemapUrls[] = [
          'loc' => $url,
          'changefreq' => $changeFreq,
          'priority' => $priority,

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can also add to it via a plugin:
 
 ```php
 use nystudio107\seomatic\events\RegisterSitemapUrlsEvent;
-use nystudio107\seomatic\SitemapCustomTemplate;
+use nystudio107\seomatic\models\SitemapCustomTemplate;
 use yii\base\Event;
 Event::on(SitemapCustomTemplate::class, SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, function(RegisterSitemapUrlsEvent $e) {
 $e->sitemapUrls[] => [

--- a/src/models/SitemapCustomTemplate.php
+++ b/src/models/SitemapCustomTemplate.php
@@ -43,7 +43,7 @@ class SitemapCustomTemplate extends FrontendTemplate implements SitemapInterface
      * use nystudio107\seomatic\models\SitemapCustomTemplate;
      * use yii\base\Event;
      * Event::on(SitemapCustomTemplate::class, SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, function(RegisterSitemapUrlsEvent $e) {
-     *     $e->sitemapUrls[] => [
+     *     $e->sitemapUrls[] = [
      *         'loc' => $url,
      *         'changefreq' => $changeFreq,
      *         'priority' => $priority,

--- a/src/models/SitemapCustomTemplate.php
+++ b/src/models/SitemapCustomTemplate.php
@@ -40,7 +40,7 @@ class SitemapCustomTemplate extends FrontendTemplate implements SitemapInterface
      * ---
      * ```php
      * use nystudio107\seomatic\events\RegisterSitemapUrlsEvent;
-     * use nystudio107\seomatic\SitemapCustomTemplate;
+     * use nystudio107\seomatic\models\SitemapCustomTemplate;
      * use yii\base\Event;
      * Event::on(SitemapCustomTemplate::class, SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, function(RegisterSitemapUrlsEvent $e) {
      *     $e->sitemapUrls[] => [

--- a/src/models/SitemapIndexTemplate.php
+++ b/src/models/SitemapIndexTemplate.php
@@ -155,7 +155,7 @@ class SitemapIndexTemplate extends FrontendTemplate implements SitemapInterface
                         'sitemapUrls' => $additionalSitemapUrls,
                         'siteId' => $groupSiteId,
                     ]);
-                    $this->trigger(SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, $event);
+                    Event::trigger(SitemapCustomTemplate::class, SitemapCustomTemplate::EVENT_REGISTER_SITEMAP_URLS, $event);
                     $additionalSitemapUrls = array_filter($event->sitemapUrls);
                     // Output the sitemap index
                     if (!empty($additionalSitemapUrls)) {

--- a/src/models/SitemapIndexTemplate.php
+++ b/src/models/SitemapIndexTemplate.php
@@ -23,6 +23,7 @@ use craft\models\SiteGroup;
 use yii\caching\TagDependency;
 use yii\helpers\Html;
 use yii\web\NotFoundHttpException;
+use yii\base\Event;
 
 /**
  * @author    nystudio107


### PR DESCRIPTION
Using the suggested code for incorporating in a plugin lead to this error:

`Class 'nystudio107\seomatic\SitemapCustomTemplate' not found`