### PR TITLE
Prevent classname conflict

### DIFF
--- a/src/helpers/JsonLd.php
+++ b/src/helpers/JsonLd.php
@@ -14,14 +14,12 @@ namespace nystudio107\seomatic\helpers;
 use nystudio107\seomatic\Seomatic;
 use nystudio107\seomatic\helpers\MetaValue as MetaValueHelper;
 
-use craft\helpers\Json;
-
 /**
  * @author    nystudio107
  * @package   Seomatic
  * @since     3.0.0
  */
-class JsonLd extends Json
+class JsonLd extends \craft\helpers\Json
 {
     // Constants
     // =========================================================================


### PR DESCRIPTION
Related to this issue: https://github.com/nystudio107/craft-seomatic/issues/209

Since the class `Json` is already defined in the `\nystudio107\seomatic\helpers` namespace, PHP doesn't know which version to pick. Older PHP versions will pick the classname that is defined in the namespace instead of being overwritten by the `use`.

Note: Untested