### PR TITLE
Fix rendering for MetaLink with multiple tags

### DIFF
--- a/src/models/MetaLink.php
+++ b/src/models/MetaLink.php
@@ -208,7 +208,7 @@ class MetaLink extends MetaItem
         foreach ($configs as $config) {
             if ($this->prepForRender($config)) {
                 ksort($config);
-                $html = Html::tag('link', '', $config);
+                $html .= Html::tag('link', '', $config);
             }
         }
 
@@ -226,7 +226,7 @@ class MetaLink extends MetaItem
         foreach ($configs as $config) {
             if ($this->prepForRender($config)) {
                 ksort($config);
-                $attributes = array_merge($attributes, $config);
+                $attributes[] = $config;
             }
         }
 

--- a/src/models/MetaLink.php
+++ b/src/models/MetaLink.php
@@ -230,6 +230,10 @@ class MetaLink extends MetaItem
             }
         }
 
+        if (\count($attributes) === 1) {
+            $attributes = $attributes[0];
+        }
+
         return $attributes;
     }
 }

--- a/src/models/MetaLink.php
+++ b/src/models/MetaLink.php
@@ -229,11 +229,7 @@ class MetaLink extends MetaItem
                 $attributes[] = $config;
             }
         }
-
-        if (\count($attributes) === 1) {
-            $attributes = $attributes[0];
-        }
-
+        
         return $attributes;
     }
 }


### PR DESCRIPTION
You'll have to decide how you want to return values here…

The current PR returns all MetaLink consistently, as arrays of tags , e.g. (notice canonical is nested):

```
    "MetaLinkContainer": {
        "canonical": [
            {
                "href": "http://localhost:8089/cloud",
                "rel": "canonical"
            }
        ],
        "alternate": [
            {
                "href": "http://localhost:8089/uk/cloud",
                "hreflang": "en-gb",
                "rel": "alternate"
            },
            {
                "href": "http://localhost:8089/cloud",
                "hreflang": "en-us",
                "rel": "alternate"
            },
            {
                "href": "http://localhost:8089/cloud",
                "hreflang": "x-default",
                "rel": "alternate"
            }
        ]
    }
```

If you _only_ want things that have multiple tags to be nested in arrays, then you'll want to add something like this before returning `$attributes`: 

```
      if (\count($attributes) === 1) {
            $attributes = $attributes[0];
        }
```