### PR TITLE
Add event to manipulate containers

### DIFF
--- a/src/base/Container.php
+++ b/src/base/Container.php
@@ -77,15 +77,20 @@ abstract class Container extends FluentModel implements ContainerInterface
     /**
      * @inheritdoc
      */
-    public function prepForInclusion(): bool
-    {
-        $include = $this->include;
-        if ($include) {
-            $include = Dependency::validateDependencies($this->dependencies);
-        }
+     public function prepForInclusion(): bool
+     {
+         $include = $this->include;
+         if ($include) {
+             $include = Dependency::validateDependencies($this->dependencies);
+         }
 
-        return $include;
-    }
+         $event = new IncludeContainerEvent([
+             'include' => $include,
+         ]);
+         $this->trigger(self::EVENT_INCLUDE_CONTAINER, $event);
+
+         return $event->include;
+     }
 
     /**
      * @inheritdoc

--- a/src/base/ContainerInterface.php
+++ b/src/base/ContainerInterface.php
@@ -23,6 +23,7 @@ interface ContainerInterface
     // =========================================================================
 
     const CONTAINER_TYPE = 'GenericContainer';
+    const EVENT_INCLUDE_CONTAINER = 'includeContainer';
 
     // Static Methods
     // =========================================================================

--- a/src/events/IncludeContainerEvent.php
+++ b/src/events/IncludeContainerEvent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * SEOmatic plugin for Craft CMS 3.x
+ *
+ * A turnkey SEO implementation for Craft CMS that is comprehensive, powerful,
+ * and flexible
+ *
+ * @link      https://nystudio107.com
+ * @copyright Copyright (c) 2017 nystudio107
+ */
+
+namespace nystudio107\seomatic\events;
+
+use yii\base\Event;
+
+/**
+ * @author    nystudio107
+ * @package   Seomatic
+ * @since     3.1.0
+ */
+class IncludeContainerEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var bool Whether to include the container.
+     */
+     public $include;
+}


### PR DESCRIPTION
I needed a place where I could manipulate the meta container before output. Here's an example usage:

```
        Event::on(
            \nystudio107\seomatic\models\MetaLinkContainer::class,
            \nystudio107\seomatic\models\MetaLinkContainer::EVENT_INCLUDE_CONTAINER,
            function(\nystudio107\seomatic\events\IncludeContainerEvent $event) {
                $container = $event->sender;
                $include = $event->include;
                $matched = \nystudio107\seomatic\Seomatic::$matchedElement;

                $alternateMeta = $container->data['alternate'];

                $alternateMeta->hreflang[] = 'en-cn';
                $alternateMeta->href[] = $matched->url;

                $alternateMeta->hreflang[] = 'en-hk';
                $alternateMeta->href[] = $matched->url;
            }
        );
```

In this case, I needed to add some alternate hreflang tags that weren't actually part of my Craft Sites config.

For my uses, it wasn't particularly important where the event was fired, as long as it happened before any rendering. I put it in `prepForInclusion` as it seems to always get called once per container. There may be a more logical place for it, but all I really needed was to be able to manipulate the container (via `$event->sender`).

Note: I was originally going to trigger it within `normalizeContainerData`, but the data from dynamic meta didn't seem to have been added yet at that point, which I needed.

Basically, wherever the "last stop for container manipulation before rendering" is where I'm looking to hook in.