### PR TITLE
Don't force jpg for SEO images

### DIFF
--- a/src/helpers/ImageTransform.php
+++ b/src/helpers/ImageTransform.php
@@ -32,7 +32,7 @@ class ImageTransform
 
     static private $transforms = [
         'base' => [
-            'format' => 'jpg',
+            'format' => null,
             'quality' => self::SOCIAL_TRANSFORM_QUALITY,
             'width' => 1200,
             'height' => 630,


### PR DESCRIPTION
We had a client creating PNGs for SEO images that ended up looking bad because they were converted to jpg. 