### PR TITLE
Include SVG in allowed social mime types

### DIFF
--- a/src/helpers/ImageTransform.php
+++ b/src/helpers/ImageTransform.php
@@ -30,6 +30,7 @@ class ImageTransform
     const ALLOWED_SOCIAL_MIME_TYPES = [
         'image/jpeg',
         'image/png',
+        'image/svg+xml',
     ];
 
     const DEFAULT_SOCIAL_FORMAT = 'jpg';


### PR DESCRIPTION
... Or else PHP will absolutely freak out trying to transform the SVG to the default social format (JPG).

This may ultimately be a Craft bug, as it should reliably detect the source as an SVG and ignore trying to transform to a bitmap format, but currently, as of 3.1.9.1, it seems it does not.