### PR TITLE
Use dash instead of underscore for sitemap urls

### DIFF
--- a/src/models/SitemapCustomTemplate.php
+++ b/src/models/SitemapCustomTemplate.php
@@ -76,11 +76,11 @@ class SitemapCustomTemplate extends FrontendTemplate implements SitemapInterface
     public static function create(array $config = [])
     {
         $defaults = [
-            'path' => 'sitemaps_<groupId:\d+>_'
+            'path' => 'sitemaps-<groupId:\d+>-'
                 .self::CUSTOM_SCOPE
-                .'_'
+                .'-'
                 .self::CUSTOM_HANDLE
-                .'_<siteId:\d+>_<file:[-\w\.*]+>',
+                .'-<siteId:\d+>-<file:[-\w\.*]+>',
             'template' => '',
             'controller' => 'sitemap',
             'action' => 'sitemap-custom',

--- a/src/models/SitemapIndexTemplate.php
+++ b/src/models/SitemapIndexTemplate.php
@@ -72,7 +72,7 @@ class SitemapIndexTemplate extends FrontendTemplate implements SitemapInterface
     public static function create(array $config = [])
     {
         $defaults = [
-            'path' => 'sitemaps_<groupId:\d+>_sitemap.xml',
+            'path' => 'sitemaps-<groupId:\d+>-sitemap.xml',
             'template' => '',
             'controller' => 'sitemap',
             'action' => 'sitemap-index',

--- a/src/models/SitemapTemplate.php
+++ b/src/models/SitemapTemplate.php
@@ -59,7 +59,7 @@ class SitemapTemplate extends FrontendTemplate implements SitemapInterface
     public static function create(array $config = [])
     {
         $defaults = [
-            'path' => 'sitemaps_<groupId:\d+>_<type:[-\w\.*]+>_<handle:[-\w\.*]+>_<siteId:\d+>_<file:[-\w\.*]+>',
+            'path' => 'sitemaps-<groupId:\d+>-<type:[\w\.*]+>-<handle:[\w\.*]+>-<siteId:\d+>-<file:[-\w\.*]+>',
             'template' => '',
             'controller' => 'sitemap',
             'action' => 'sitemap',

--- a/src/services/Sitemaps.php
+++ b/src/services/Sitemaps.php
@@ -294,9 +294,9 @@ class Sitemaps extends Component implements SitemapInterface
         if ($site !== null) {
             try {
                 $url = UrlHelper::siteUrl(
-                    '/sitemaps_'
+                    '/sitemaps-'
                     .$site->groupId
-                    .'_sitemap.xml',
+                    .'-sitemap.xml',
                     null,
                     null,
                     $siteId
@@ -325,15 +325,15 @@ class Sitemaps extends Component implements SitemapInterface
         if ($site) {
             try {
                 $url = UrlHelper::siteUrl(
-                    '/sitemaps_'
+                    '/sitemaps-'
                     .$site->groupId
-                    .'_'
+                    .'-'
                     .SitemapCustomTemplate::CUSTOM_SCOPE
-                    .'_'
+                    .'-'
                     .SitemapCustomTemplate::CUSTOM_HANDLE
-                    .'_'
+                    .'-'
                     .$siteId
-                    .'_sitemap.xml',
+                    .'-sitemap.xml',
                     null,
                     null,
                     $siteId
@@ -369,15 +369,15 @@ class Sitemaps extends Component implements SitemapInterface
         if ($site && $metaBundle) {
             try {
                 $url = UrlHelper::siteUrl(
-                    '/sitemaps_'
+                    '/sitemaps-'
                     .$site->groupId
-                    .'_'
+                    .'-'
                     .$metaBundle->sourceBundleType
-                    .'_'
+                    .'-'
                     .$metaBundle->sourceHandle
-                    .'_'
+                    .'-'
                     .$metaBundle->sourceSiteId
-                    .'_sitemap.xml',
+                    .'-sitemap.xml',
                     null,
                     null,
                     $siteId


### PR DESCRIPTION
Craft handles can have underscores in their name.
This means that splitting the sitemap paths using underscores will not work if the section itself have one or more underscore in their handle.

Handles can not have dash in their name afaik, so maybe we can use dash instead of underscore to split between group, type, handle and so on.

This pull request is trying to fix #335 

Apart from changing the urls from `_` to `-`, I've also removed dash from the handle regex as it will never be used there if I'm understanding the code correctly.

Thoughts @khalwat?