### PR TITLE
Added CraftQL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SEOmatic Changelog
 
+### Added
+* Added CraftQL support for entries. Use the graphql `seoMatic` field.
+
 ## 3.1.50 - 2019.04.30
 ### Added
 * Added the `???` Empty Coalesce operator to allow for the easy cascading of default text/image SEO values

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ The Plugin Settings lets you control various SEOmatic settings globally (across 
 * **Control Panel `<title>` prefix** - Prefix the Control Panel `<title>` with this string
 * **devMode Control Panel `<title>` prefix** - If devMode is on, prefix the Control Panel `<title>` with this string
 * **Separator Character** - The separator character to use for the `<title>` tag
-* **Max SEO Title Length** - The max number of characters in the <title> tag; anything beyond this will be truncated on word boundaries
+* **Max SEO Title Length** - The max number of characters in the `<title>` tag; anything beyond this will be truncated on word boundaries
 * **Max SEO Description Length** - The max number of characters in the `meta description` tag
 * **Site Groups define logically separate sites** - If you are using Site Groups to logically separate 'sister sites', turn this on.
 * **Add `hreflang` Tags** - Controls whether SEOmatic will automatically add `hreflang` and `og:locale:alternate` tags.

--- a/README.md
+++ b/README.md
@@ -1755,6 +1755,21 @@ You can narrow this down to a specific sub-type list by passing in a `path` of s
 }
 ```
 
+## CraftQL Query support
+
+To retrieve SEOmatic data through the CraftQL plugin, use the `seoMatic` field in your graphql query. Each option will return it's own JSON-LD data.
+Use the following field inside a query:
+
+```gql
+seoMatic {
+    MetaTitleContainer
+    MetaTagContainer
+    MetaLinkContainer
+    MetaScriptContainer
+    MetaJsonLdContainer
+}
+```
+
 ## SEOmatic Roadmap
 
 Some things to do, and ideas for potential features:

--- a/README.md
+++ b/README.md
@@ -1762,11 +1762,11 @@ Use the following field inside a query:
 
 ```gql
 seoMatic {
-    MetaTitleContainer
-    MetaTagContainer
-    MetaLinkContainer
-    MetaScriptContainer
-    MetaJsonLdContainer
+    metaTitleContainer
+    metaTagContainer
+    metaLinkContainer
+    metaScriptContainer
+    metaJsonLdContainer
 }
 ```
 

--- a/src/Seomatic.php
+++ b/src/Seomatic.php
@@ -440,6 +440,15 @@ class Seomatic extends Plugin
                 }
             }
         );
+
+        // CraftQL Support
+        if (class_exists(\markhuot\CraftQL\CraftQL::class)) {
+            Event::on(
+                \markhuot\CraftQL\Types\EntryInterface::class,
+                \markhuot\CraftQL\Events\AlterSchemaFields::EVENT,
+                [new \nystudio107\seomatic\helpers\CraftQLSchemaHelper, 'handle']
+            );
+        }
     }
 
     /**

--- a/src/helpers/CraftQLSchemaHelper.php
+++ b/src/helpers/CraftQLSchemaHelper.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace nystudio107\seomatic\helpers;
+
+use nystudio107\seomatic\Seomatic;
+use nystudio107\seomatic\models\MetaJsonLdContainer;
+use nystudio107\seomatic\models\MetaLinkContainer;
+use nystudio107\seomatic\models\MetaScriptContainer;
+use nystudio107\seomatic\models\MetaTitleContainer;
+use nystudio107\seomatic\models\MetaTagContainer;
+
+use markhuot\CraftQL\Events\AlterSchemaFields;
+
+use Craft;
+use craft\base\Element;
+
+use yii\caching\TagDependency;
+
+class CraftQLSchemaHelper
+{
+    // Constants
+    // =========================================================================
+
+    const CACHE_KEY = 'seomatic_metacontroller_';
+
+    public function handle(AlterSchemaFields $event)
+    {
+        $seoMaticField = $event->schema->createObjectType('SEOMaticData');
+
+        $seoMaticField->addStringField('MetaTitleContainer')->resolve(function (Element $element) {
+            // $root contains the data returned by the field below
+            $result = $this->getContainerArrays(
+                [
+                    MetaTitleContainer::CONTAINER_TYPE,
+                ],
+                $element
+            );
+            return $result['MetaTitleContainer'];
+        });
+
+        $seoMaticField->addStringField('MetaTagContainer')->resolve(function (Element $element) {
+            // $root contains the data returned by the field below
+            $result = $this->getContainerArrays(
+                [
+                    MetaTagContainer::CONTAINER_TYPE,
+                ],
+                $element
+            );
+            return $result['MetaTagContainer'];
+        });
+
+        $seoMaticField->addStringField('MetaLinkContainer')->resolve(function (Element $element) {
+            // $root contains the data returned by the field below
+            $result = $this->getContainerArrays(
+                [
+                    MetaLinkContainer::CONTAINER_TYPE,
+                ],
+                $element
+            );
+            return $result['MetaLinkContainer'];
+        });
+
+        $seoMaticField->addStringField('MetaScriptContainer')->resolve(function (Element $element) {
+            // $root contains the data returned by the field below
+            $result = $this->getContainerArrays(
+                [
+                    MetaScriptContainer::CONTAINER_TYPE,
+                ],
+                $element
+            );
+            return $result['MetaScriptContainer'];
+        });
+
+        $seoMaticField->addStringField('MetaJsonLdContainer')->resolve(function (Element $element) {
+            // $root contains the data returned by the field below
+            $result = $this->getContainerArrays(
+                [
+                    MetaJsonLdContainer::CONTAINER_TYPE,
+                ],
+                $element
+            );
+            return $result['MetaJsonLdContainer'];
+        });
+
+        $event->schema->addField('seoMatic')
+            ->type($seoMaticField)
+            ->resolve(function (Element $root) {
+                // Return the root, which is the requested Entry for usage in the fields.
+                return $root;
+            });
+    }
+
+    // Protected Methods
+    // =========================================================================
+
+    protected function getContainerArrays(
+        array $containerKeys,
+        Element $element,
+        bool $asArray = false
+    ): array {
+        $result = [];
+
+        // Normalize the incoming URI to account for `__home__`
+        $uri = ($element->uri === '__home__') ? '' : $element->uri;
+        $siteId = $element->siteId;
+
+        // Determine the siteId
+        if ($siteId === null) {
+            $siteId = Craft::$app->getSites()->currentSite->id
+                ?? Craft::$app->getSites()->primarySite->id
+                ?? 1;
+        }
+        $uri = trim($uri, '/');
+
+        // Add a caching layer on top of controller requests
+        $sourceId = '';
+
+        list($sourceId, $sourceBundleType, $sourceHandle, $sourceSiteId)
+            = Seomatic::$plugin->metaBundles->getMetaSourceFromElement($element);
+
+        $metaContainers = Seomatic::$plugin->metaContainers;
+        // Get our cache key
+        $asArrayKey = $asArray ? 'true' : 'false';
+        $cacheKey = $uri.$siteId.implode($containerKeys).$asArrayKey;
+        // Load the meta containers
+        $dependency = new TagDependency([
+            'tags' => [
+                $metaContainers::GLOBAL_METACONTAINER_CACHE_TAG,
+                $metaContainers::METACONTAINER_CACHE_TAG.$sourceId,
+                $metaContainers::METACONTAINER_CACHE_TAG.$uri.$siteId,
+                $metaContainers::METACONTAINER_CACHE_TAG.$cacheKey,
+            ],
+        ]);
+
+        $cache = Craft::$app->getCache();
+        $result = $cache->getOrSet(
+            $this::CACHE_KEY.$cacheKey,
+            function () use ($uri, $siteId, $containerKeys, $asArray) {
+                $result = [];
+                Craft::info(
+                    'Meta controller container cache miss: '.$uri.'/'.$siteId,
+                    __METHOD__
+                );
+                // Load the meta containers and parse our globals
+                Seomatic::$plugin->metaContainers->previewMetaContainers($uri, $siteId, true);
+
+                // Iterate through the desired $containerKeys
+                foreach ($containerKeys as $containerKey) {
+                    if ($asArray) {
+                        $result[$containerKey] = Seomatic::$plugin->metaContainers->renderContainersArrayByType(
+                            $containerKey
+                        );
+                    } else {
+                        $result[$containerKey] = Seomatic::$plugin->metaContainers->renderContainersByType(
+                            $containerKey
+                        );
+                    }
+                }
+
+                return $result;
+            },
+            Seomatic::$cacheDuration,
+            $dependency
+        );
+
+        return $result;
+    }
+}

--- a/src/helpers/CraftQLSchemaHelper.php
+++ b/src/helpers/CraftQLSchemaHelper.php
@@ -27,7 +27,7 @@ class CraftQLSchemaHelper
     {
         $seoMaticField = $event->schema->createObjectType('SEOMaticData');
 
-        $seoMaticField->addStringField('MetaTitleContainer')->resolve(function (Element $element) {
+        $seoMaticField->addStringField('metaTitleContainer')->resolve(function (Element $element) {
             // $root contains the data returned by the field below
             $result = $this->getContainerArrays(
                 [
@@ -38,7 +38,7 @@ class CraftQLSchemaHelper
             return $result['MetaTitleContainer'];
         });
 
-        $seoMaticField->addStringField('MetaTagContainer')->resolve(function (Element $element) {
+        $seoMaticField->addStringField('metaTagContainer')->resolve(function (Element $element) {
             // $root contains the data returned by the field below
             $result = $this->getContainerArrays(
                 [
@@ -49,7 +49,7 @@ class CraftQLSchemaHelper
             return $result['MetaTagContainer'];
         });
 
-        $seoMaticField->addStringField('MetaLinkContainer')->resolve(function (Element $element) {
+        $seoMaticField->addStringField('metaLinkContainer')->resolve(function (Element $element) {
             // $root contains the data returned by the field below
             $result = $this->getContainerArrays(
                 [
@@ -60,7 +60,7 @@ class CraftQLSchemaHelper
             return $result['MetaLinkContainer'];
         });
 
-        $seoMaticField->addStringField('MetaScriptContainer')->resolve(function (Element $element) {
+        $seoMaticField->addStringField('metaScriptContainer')->resolve(function (Element $element) {
             // $root contains the data returned by the field below
             $result = $this->getContainerArrays(
                 [
@@ -71,7 +71,7 @@ class CraftQLSchemaHelper
             return $result['MetaScriptContainer'];
         });
 
-        $seoMaticField->addStringField('MetaJsonLdContainer')->resolve(function (Element $element) {
+        $seoMaticField->addStringField('metaJsonLdContainer')->resolve(function (Element $element) {
             // $root contains the data returned by the field below
             $result = $this->getContainerArrays(
                 [


### PR DESCRIPTION
To retrieve SEOmatic data through the CraftQL plugin, use the `seoMatic` field in your graphql query. Each option will return it's own JSON-LD data.
Use the following field inside a query:

```gql
seoMatic {
    metaTitleContainer
    metaTagContainer
    metaLinkContainer
    metaScriptContainer
    metaJsonLdContainer
}
```