### PR TITLE
Don't load duplicates for Calendar Events

### DIFF
--- a/src/seoelements/SeoEvent.php
+++ b/src/seoelements/SeoEvent.php
@@ -197,6 +197,7 @@ class SeoEvent implements SeoElementInterface
     {
         $query = Event::find()
             ->setCalendar($metaBundle->sourceHandle)
+            ->setLoadOccurrences(false)
             ->siteId($metaBundle->sourceSiteId)
             ->limit($metaBundle->metaSitemapVars->sitemapLimit)
             ->enabledForSite(true);


### PR DESCRIPTION
Hey Guys

SEOMatic includes multiple instances of the same event in the Sitemap when indexing recurring Calendar Events. This PR ensures that only one instance of each event is returned when querying the database by setting the [loadOccurrences](https://docs.solspace.com/craft/calendar/v2/template-functions/calendar.events.html#parameters) parameter to false