### PR TITLE
Bump required Craft version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SEOmatic is the SEO tool that the SEO experts at [Moz.com](https://moz.com/) and
 
 ## Requirements
 
-This plugin requires Craft CMS 3.0.20 or later.
+This plugin requires Craft CMS 3.3.12 or later.
 
 ## Installation
 


### PR DESCRIPTION
Craft versions below 3.3.12 gets a server error whenever you try to save any changes to the SEOMatic settings. "Calling unknown method: craft\services\Gql::invalidateCaches()" (which was introduced in 3.3.12)