### PR TITLE
Fixed some category JsonLd dates to dateCreated as categories doesn't have postDate

### DIFF
--- a/src/seomatic-config/categorymeta/JsonLdContainer.php
+++ b/src/seomatic-config/categorymeta/JsonLdContainer.php
@@ -38,8 +38,8 @@ return [
                 'mainEntityOfPage' => '{seomatic.meta.canonicalUrl}',
                 'dateCreated'      => '{category.dateCreated |atom}',
                 'dateModified'     => '{category.dateUpdated |atom}',
-                'datePublished'    => '{category.postDate |atom}',
-                'copyrightYear'    => '{category.postDate |date("Y")}',
+                'datePublished'    => '{category.dateCreated |atom}',
+                'copyrightYear'    => '{category.dateCreated |date("Y")}',
                 'inLanguage'       => '{seomatic.meta.language}',
                 'copyrightHolder'  => [
                     'id' => '{seomatic.site.identity.genericUrl}#identity',


### PR DESCRIPTION
JsonLd template for categories relies on `category.postDate` for `datePublished` and `copyrightYear` fields. As categories doesn't have postDate field, templates that renders categories would use the current date/time as twig defaults to current date/time if a valid date si not found. This is PR makes `datePublished` and `copyrightYear` use the `category.dateCreated`. 

The problem is impacting seo and static site generators because `datePublished` changes at each page reload.