### PR TITLE
Take keys into account when comparing defaults with values

### DIFF
--- a/src/fields/SeoSettings.php
+++ b/src/fields/SeoSettings.php
@@ -256,7 +256,7 @@ class SeoSettings extends Field implements PreviewableFieldInterface
                     $bundleAttributes = $metaBundle->$fieldName->getAttributes();
                     $fieldAttributes = $value->$fieldName->getAttributes();
                     if (!empty($bundleAttributes) && !empty($fieldAttributes)) {
-                        $intersect = array_intersect($bundleAttributes, $fieldAttributes);
+                        $intersect = array_intersect_assoc($bundleAttributes, $fieldAttributes);
                         $intersect = array_filter(
                             $intersect,
                             [ArrayHelper::class, 'preserveBools']


### PR DESCRIPTION
This change was added because it would override the contents of a field where the default value already existed in another field. Here's an example:

**Default values**
- seoTitle: `{seomatic.helper.extractTextFromField(object.entry.title)}`
- seoImageDescription: `{seomatic.helper.extractTextFromField(object.entry.title)}`

**New values**
- seoTitle: `Custom title of the page`
- seoImageDescription: `{seomatic.helper.extractTextFromField(object.entry.title)}`

The `seoTitle` field got nullified because array_intersect found a row in the values with the same default value. 