### PR TITLE
Remove deprecated references to enabledForSite (Craft 3.5)

### DIFF
--- a/src/helpers/DynamicMeta.php
+++ b/src/helpers/DynamicMeta.php
@@ -572,7 +572,7 @@ class DynamicMeta
                     $element = $elements->getElementByUri($url, $site->id, false);
                 }
                 if ($element !== null) {
-                    if (isset($element->enabledForSite) && !(bool)$element->enabledForSite) {
+                    if (!(bool)$element->enabled) {
                         $includeUrl = false;
                     }
                     /** @var MetaBundle $metaBundle */

--- a/src/jobs/GenerateSitemap.php
+++ b/src/jobs/GenerateSitemap.php
@@ -389,7 +389,7 @@ class GenerateSitemap extends BaseJob
      */
     protected function assetSitemapItem(Asset $asset, MetaBundle $metaBundle, array &$lines)
     {
-        if ((bool)$asset->enabledForSite && $asset->getUrl() !== null) {
+        if ((bool)$asset->enabled && $asset->getUrl() !== null) {
             switch ($asset->kind) {
                 case 'image':
                     $lines[] = '<image:image>';
@@ -437,7 +437,7 @@ class GenerateSitemap extends BaseJob
      */
     protected function assetFilesSitemapLink(Asset $asset, MetaBundle $metaBundle, array &$lines)
     {
-        if ((bool)$asset->enabledForSite && $asset->getUrl() !== null) {
+        if ((bool)$asset->enabled && $asset->getUrl() !== null) {
             if (\in_array($asset->kind, SitemapTemplate::FILE_TYPES, false)) {
                 $dateUpdated = $asset->dateUpdated ?? $asset->dateCreated ?? new \DateTime;
                 $lines[] = '<url>';

--- a/src/seoelements/SeoCategory.php
+++ b/src/seoelements/SeoCategory.php
@@ -192,8 +192,7 @@ class SeoCategory implements SeoElementInterface
         $query = Category::find()
             ->group($metaBundle->sourceHandle)
             ->siteId($metaBundle->sourceSiteId)
-            ->limit($metaBundle->metaSitemapVars->sitemapLimit)
-            ->enabledForSite(true);
+            ->limit($metaBundle->metaSitemapVars->sitemapLimit);
         if (!empty($metaBundle->metaSitemapVars->structureDepth)) {
             $query->level($metaBundle->metaSitemapVars->structureDepth.'<=');
         }
@@ -220,7 +219,6 @@ class SeoCategory implements SeoElementInterface
             ->id($elementId)
             ->siteId($siteId)
             ->limit(1)
-            ->enabledForSite(true)
             ->one();
     }
 

--- a/src/seoelements/SeoDigitalProduct.php
+++ b/src/seoelements/SeoDigitalProduct.php
@@ -199,9 +199,7 @@ class SeoDigitalProduct implements SeoElementInterface
         $query = Product::find()
             ->type($metaBundle->sourceHandle)
             ->siteId($metaBundle->sourceSiteId)
-            ->limit($metaBundle->metaSitemapVars->sitemapLimit)
-            ->enabledForSite(true)
-        ;
+            ->limit($metaBundle->metaSitemapVars->sitemapLimit);
 
         return $query;
     }
@@ -225,7 +223,6 @@ class SeoDigitalProduct implements SeoElementInterface
             ->id($elementId)
             ->siteId($siteId)
             ->limit(1)
-            ->enabledForSite(true)
             ->one();
     }
 

--- a/src/seoelements/SeoEntry.php
+++ b/src/seoelements/SeoEntry.php
@@ -195,7 +195,6 @@ class SeoEntry implements SeoElementInterface
         $query = Entry::find()
             ->section($metaBundle->sourceHandle)
             ->siteId($metaBundle->sourceSiteId)
-            ->enabledForSite(true)
             ->limit($metaBundle->metaSitemapVars->sitemapLimit);
         if ($metaBundle->sourceType === 'structure'
             && !empty($metaBundle->metaSitemapVars->structureDepth)) {
@@ -224,7 +223,6 @@ class SeoEntry implements SeoElementInterface
             ->section($metaBundle->sourceHandle)
             ->id($elementId)
             ->siteId($siteId)
-            ->enabledForSite(true)
             ->limit(1)
             ->one();
     }

--- a/src/seoelements/SeoEvent.php
+++ b/src/seoelements/SeoEvent.php
@@ -199,8 +199,7 @@ class SeoEvent implements SeoElementInterface
             ->setCalendar($metaBundle->sourceHandle)
             ->setLoadOccurrences(false)
             ->siteId($metaBundle->sourceSiteId)
-            ->limit($metaBundle->metaSitemapVars->sitemapLimit)
-            ->enabledForSite(true);
+            ->limit($metaBundle->metaSitemapVars->sitemapLimit);
 
         return $query;
     }
@@ -224,7 +223,6 @@ class SeoEvent implements SeoElementInterface
             ->id($elementId)
             ->siteId($siteId)
             ->limit(1)
-            ->enabledForSite(true)
             ->one();
     }
 

--- a/src/seoelements/SeoProduct.php
+++ b/src/seoelements/SeoProduct.php
@@ -199,9 +199,7 @@ class SeoProduct implements SeoElementInterface
         $query = Product::find()
             ->type($metaBundle->sourceHandle)
             ->siteId($metaBundle->sourceSiteId)
-            ->limit($metaBundle->metaSitemapVars->sitemapLimit)
-            ->enabledForSite(true)
-        ;
+            ->limit($metaBundle->metaSitemapVars->sitemapLimit);
 
         return $query;
     }
@@ -225,7 +223,6 @@ class SeoProduct implements SeoElementInterface
             ->id($elementId)
             ->siteId($siteId)
             ->limit(1)
-            ->enabledForSite(true)
             ->one();
     }
 


### PR DESCRIPTION
enabledForSite is deprecated in 3.5 https://github.com/craftcms/cms/issues/6273