### PR TITLE
FIxed better checks for `InStock` for Product JSON-LD schema

### DIFF
--- a/src/seomatic-config/productmeta/JsonLdContainer.php
+++ b/src/seomatic-config/productmeta/JsonLdContainer.php
@@ -74,7 +74,7 @@ return [
                     'seller'        => [
                         'id' => '{seomatic.site.identity.genericUrl}#identity',
                     ],
-                    'availability'  => 'http://schema.org/{% if object.product.unlimitedStock or object.product.totalStock > 0 %}InStock{% else %}OutOfStock{% endif %}',
+                    'availability'  => 'http://schema.org/{% if object.product.hasUnlimitedStock or object.product.totalStock > 0 %}InStock{% else %}OutOfStock{% endif %}',
                 ],
             ],
         ],


### PR DESCRIPTION
### Description
There is no unlimitedStock property in Product. Product has hasUnlimitedStock property.

### Related issues
https://github.com/nystudio107/craft-seomatic/issues/797