### PR TITLE
Helper: pass through all siteUrl parameters

### DIFF
--- a/src/services/Helper.php
+++ b/src/services/Helper.php
@@ -164,7 +164,7 @@ class Helper extends Component
      */
     public static function siteUrl(string $path = '', $params = null, string $scheme = null, int $siteId = null): string
     {
-        return UrlHelper::siteUrl($path);
+        return UrlHelper::siteUrl($path, $params, $scheme, $siteId);
     }
 
     /**


### PR DESCRIPTION
Rather than just the `$path` parameter.

I'm not aware of this actually affecting or fixing anything, but it looked like an oversight when I came across it. You will certainly know better!