### PR TITLE
Use getGeneral() method

### DIFF
--- a/src/helpers/DynamicMeta.php
+++ b/src/helpers/DynamicMeta.php
@@ -327,7 +327,7 @@ class DynamicMeta
         try {
             $siteUrl = SiteHelper::siteEnabledWithUrls($siteId) ? $site->baseUrl : Craft::$app->getSites()->getPrimarySite()->baseUrl;
         } catch (SiteNotFoundException $e) {
-            $siteUrl = Craft::$app->getConfig()->general->siteUrl;
+            $siteUrl = Craft::$app->getConfig()->getGeneral()->siteUrl;
             Craft::error($e->getMessage(), __METHOD__);
         }
         if (!empty(Seomatic::$settings->siteUrlOverride)) {


### PR DESCRIPTION
### Description

Just for consistency. This call to the general config service can use the `getGeneral()` method. It appears in most places where getConfig() is used, this already the case.