### PR TITLE
Fix `security.txt` template

### DIFF
--- a/src/templates/_frontend/pages/security.twig
+++ b/src/templates/_frontend/pages/security.twig
@@ -1,15 +1,16 @@
 # security.txt file for {{ siteUrl }} - more info: https://securitytxt.org/
+
 # (required) Contact email address for security issues
-Contact: user@example.com
+Contact: mailto:user@example.com
 
 # (required) Expiration date for the security information herein
-Expiration: {{ date('1year')|atom }}
+Expires: {{ date('1year')|atom }}
 
 # (optional) OpenPGP key:
-Encryption: {{ siteUrl }}pgp-key.txt
+Encryption: {{ url('pgp-key.txt') }}
 
 # (optional) Security policy page:
-Policy: {{ siteUrl }}security-policy
+Policy: {{ url('security-policy') }}
 
 # (optional) Security acknowledgements page:
-Acknowledgements: {{ siteUrl }}hall-of-fame
+Acknowledgements: {{ url('hall-of-fame') }}

--- a/src/templates/_frontend/pages/security.twig
+++ b/src/templates/_frontend/pages/security.twig
@@ -4,7 +4,7 @@
 Contact: mailto:user@example.com
 
 # (required) Expiration date for the security information herein
-Expires: {{ date('1year')|atom }}
+Expires: {{ date('+1 year')|atom }}
 
 # (optional) OpenPGP key:
 Encryption: {{ url('pgp-key.txt') }}


### PR DESCRIPTION
Fixes some issues with the `security.txt` template, following the spec at https://datatracker.ietf.org/doc/html/draft-foudil-securitytxt-12.

1. Add `mailto:` to `Contact` (fix)
2. `Expiration` → `Expires` (fix)
3. `date('1year')` → `date('+1 year')` (readability)
4. `{{ siteUrl }}segment` → `{{ url('segment') }}` (stability)