### PR TITLE
Fixes General Variables link

### DIFF
--- a/docs/docs/fields.md
+++ b/docs/docs/fields.md
@@ -54,7 +54,7 @@ To access your SEOmatic field’s data directly in a template, you can do so via
 {{ entry.mySeoSettingsField.metaGlobalVars.seoTitle }}
 ```
 
-All of the variables listed in the [General Variables](#general-variables) can be accessed in this manner.
+All of the variables listed in the [General Variables](./using.html#general-variables) can be accessed in this manner.
 
 There may be occasions where you want to output the final parsed value of an SEOmatic variable on the frontend. You can do that via `entry.mySeoSettingsField.metaGlobalVars.parsedValue()`. For example:
 


### PR DESCRIPTION
### Description

The General Variables link on the Fields page (under Template Access) was not correct.
