### PR TITLE
Add str_contains polyfill for php < 8

### DIFF
--- a/src/helpers/MetaValue.php
+++ b/src/helpers/MetaValue.php
@@ -233,7 +233,24 @@ class MetaValue
 
     // Protected Methods
     // =========================================================================
-
+    
+    /**
+     * `str_contains` polyfill for PHP < 8.0
+     *
+     * @param string $haystack
+     * @param string $needle
+     *
+     * @return bool
+     */
+    protected static function internalStrContains($haystack, $needle)
+    {
+        if (function_exists('str_contains')) {
+            return str_contains($haystack, $needle);
+        } else {
+            return StringHelper::contains($haystack, $needle);
+        }
+    }
+    
     /**
      * @param string|Asset $metaValue
      * @param bool $resolveAliases Whether @ aliases should be resolved


### PR DESCRIPTION
### Description

`str_contains` doesn't exist in php < 8. This PR adds a lil' polyfill to check for `str_contains`, and if it doesn't exist, use `StringHelper::contains`

### Related issues

- closes #1221