### PR TITLE
Fix query level structureDepth 'Invalid numeric value: 1<='

### DIFF
--- a/src/seoelements/SeoCategory.php
+++ b/src/seoelements/SeoCategory.php
@@ -224,7 +224,7 @@ class SeoCategory implements SeoElementInterface, GqlSeoElementInterface
             ->siteId($metaBundle->sourceSiteId)
             ->limit($metaBundle->metaSitemapVars->sitemapLimit);
         if (!empty($metaBundle->metaSitemapVars->structureDepth)) {
-            $query->level($metaBundle->metaSitemapVars->structureDepth . '<=');
+            $query->level('<=' . $metaBundle->metaSitemapVars->structureDepth);
         }
 
         return $query;

--- a/src/seoelements/SeoEntry.php
+++ b/src/seoelements/SeoEntry.php
@@ -227,7 +227,7 @@ class SeoEntry implements SeoElementInterface, GqlSeoElementInterface
             ->limit($metaBundle->metaSitemapVars->sitemapLimit);
         if ($metaBundle->sourceType === 'structure'
             && !empty($metaBundle->metaSitemapVars->structureDepth)) {
-            $query->level($metaBundle->metaSitemapVars->structureDepth . '<=');
+            $query->level('<=' . $metaBundle->metaSitemapVars->structureDepth);
         }
 
         return $query;


### PR DESCRIPTION
Fix Exception 'yii\base\InvalidArgumentException' with message 'Invalid numeric value: 1<='

### Description

Got this error when running `craft seomatic/sitemap/generate`