### PR TITLE
Add Doxter fieldtype to v4

### DIFF
--- a/src/helpers/Field.php
+++ b/src/helpers/Field.php
@@ -31,6 +31,7 @@ use nystudio107\seomatic\fields\Seomatic_Meta as Seomatic_MetaField;
 use nystudio107\seomatic\fields\SeoSettings as SeoSettingsField;
 use nystudio107\seomatic\Seomatic;
 use nystudio107\seomatic\services\MetaBundles;
+use verbb\doxter\fields\Doxter as DoxterField;
 use verbb\supertable\elements\SuperTableBlockElement as SuperTableBlock;
 use verbb\supertable\fields\SuperTableField;
 use yii\base\InvalidConfigException;
@@ -61,6 +62,7 @@ class Field
             NeoField::class,
             SuperTableField::class,
             PreparseFieldType::class,
+            DoxterField::class,
         ],
         self::ASSET_FIELD_CLASS_KEY => [
             AssetsField::class,

--- a/src/helpers/Text.php
+++ b/src/helpers/Text.php
@@ -23,6 +23,7 @@ use nystudio107\seomatic\Seomatic;
 use PhpScience\TextRank\TextRankFacade;
 use PhpScience\TextRank\Tool\StopWords\StopWordsAbstract;
 use Stringy\Stringy;
+use verbb\doxter\Doxter;
 use verbb\doxter\fields\data\DoxterData;
 use verbb\supertable\elements\db\SuperTableBlockQuery;
 use verbb\supertable\elements\SuperTableBlockElement as SuperTableBlock;

--- a/src/helpers/Text.php
+++ b/src/helpers/Text.php
@@ -23,6 +23,7 @@ use nystudio107\seomatic\Seomatic;
 use PhpScience\TextRank\TextRankFacade;
 use PhpScience\TextRank\Tool\StopWords\StopWordsAbstract;
 use Stringy\Stringy;
+use verbb\doxter\fields\data\DoxterData;
 use verbb\supertable\elements\db\SuperTableBlockQuery;
 use verbb\supertable\elements\SuperTableBlockElement as SuperTableBlock;
 use yii\base\InvalidConfigException;
@@ -125,6 +126,8 @@ class Text
         } elseif ($field instanceof TagQuery
             || (is_array($field) && $field[0] instanceof Tag)) {
             $result = self::extractTextFromTags($field);
+        } elseif ($field instanceof DoxterData) {
+            $result = self::smartStripTags(Doxter::$plugin->getService()->parseMarkdown($field->getRaw()));
         } else {
             if (is_array($field)) {
                 $result = self::smartStripTags((string)$field[0]);


### PR DESCRIPTION
This PR adds the Doxter fieldtype to the available fields that SEOmatic v4 can parse.