### PR TITLE
Update description and dashboard for Craft CMS 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "nystudio107/craft-seomatic",
-  "description": "SEOmatic facilitates modern SEO best practices & implementation for Craft CMS 3. It is a turnkey SEO system that is comprehensive, powerful, and flexible.",
+  "description": "SEOmatic facilitates modern SEO best practices & implementation for Craft CMS 4. It is a turnkey SEO system that is comprehensive, powerful, and flexible.",
   "type": "craft-plugin",
   "version": "4.0.21",
   "keywords": [

--- a/src/templates/dashboard/index.twig
+++ b/src/templates/dashboard/index.twig
@@ -75,7 +75,7 @@
                     <img src="{{ baseAssetsUrl ~ '/img/Seomatic-icon.svg' }}"
                          width="30%" height="auto"/>
                     <h2>Thanks for using SEOmatic!</h2>
-                    <p>SEOmatic facilitates modern SEO best practices & implementation for Craft CMS 3. It is a turnkey
+                    <p>SEOmatic facilitates modern SEO best practices & implementation for Craft CMS 4. It is a turnkey
                         SEO system that is comprehensive, powerful, and flexible.</p>
                     <p>We hope you love it! For more information, please <a href="{{ docsUrl }}" target="_blank"
                                                                             rel="noopener">see the documentation</a>.


### PR DESCRIPTION
Very minor change; I noticed when I recently did a fresh install on a Craft 4 site that the dashboard still says "Craft CMS 3"