### PR TITLE
Fix cache-busting param on seo images

### DIFF
--- a/src/helpers/ImageTransform.php
+++ b/src/helpers/ImageTransform.php
@@ -152,8 +152,9 @@ class ImageTransform
             // If we have a url, add an `mtime` param to cache bust
             if (!empty($url) && empty(parse_url($url, PHP_URL_QUERY))) {
                 $now = new \DateTime();
+                $newestChange = max($asset->dateModified, $asset->dateUpdated);
                 $url = UrlHelper::url($url, [
-                    'mtime' => $asset->dateModified->getTimestamp() ?? $now->getTimestamp(),
+                    'mtime' => $newestChange->getTimestamp() ?? $now->getTimestamp(),
                 ]);
             }
         }


### PR DESCRIPTION
### Description
Changed the mtime param to use the latest of dateModified and dateUpdated to ensure asset settings changes are registered.

### Related issues
Issue 1309