### PR TITLE
fix: Syntax error in older versions of PHP

### DIFF
--- a/src/models/MetaScriptContainer.php
+++ b/src/models/MetaScriptContainer.php
@@ -140,7 +140,7 @@ class MetaScriptContainer extends NonceContainer
             if ($bodyJs) {
                 Seomatic::$view->registerHtml(
                     $config['js'],
-                    $config['position'],
+                    $config['position']
                 );
             } else {
                 Seomatic::$view->registerScript(


### PR DESCRIPTION
### Description

Getting the follow error using PHP 7.2

`ParseError: syntax error, unexpected ')' in /www/rvtgroup.co.uk/production/shared/vendor/nystudio107/craft-seomatic/src/models/MetaScriptContainer.php:144`
