### PR TITLE
Fix tag to disable rendering of alternate link

### DIFF
--- a/docs/docs/technologies.md
+++ b/docs/docs/technologies.md
@@ -64,7 +64,7 @@ Sites that are grouped together under the same Site Group will have `<link rel="
 
 To disable SEOmatic’s automatic rendering of these tags, you can do:
 ```twig
-{% do seomatic.tag.get('alternate').include(false) %}
+{% do seomatic.link.get('alternate').include(false) %}
 {% do seomatic.tag.get('og:locale:alternate').include(false) %}
 ```
 


### PR DESCRIPTION
The current sample code results in `Impossible to invoke a method ("include") on a null variable.`

`alternate` is a link, not a tag.