### PR TITLE
Try to use Craft's matched element from `UrlManager` in `MetaContainers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 * Fixed an issue where the `CanonicalLink` would render if the `Robots` tag contained multiple values ([#1378](https://github.com/nystudio107/craft-seomatic/issues/1378))
 
+### Changed
+* Try to use Craft's matched element from `UrlManager` in `MetaContainers` if looking for an enabled element, the current `siteId` is being used and the current `uri` matches what was in the request
+
 ## 4.0.33 - 2023.10.22
 ### Added
 * Added an SEOmatic debug panel to the Yii2 Debug Toolbar to aid in debugging SEO metadata

--- a/src/services/MetaContainers.php
+++ b/src/services/MetaContainers.php
@@ -893,10 +893,21 @@ class MetaContainers extends Component
                 ?? Craft::$app->getSites()->primarySite->id
                 ?? 1;
         }
+        $element = null;
         $uri = trim($uri, '/');
         /** @var Element $element */
         $enabledOnly = !Seomatic::$previewingMetaContainers;
-        $element = Craft::$app->getElements()->getElementByUri($uri, $siteId, $enabledOnly);
+        // Try to use Craft's matched element if looking for an enabled element, the current `siteId` is being used and
+        // the current `uri` matches what was in the request
+        if ($enabledOnly
+            && $siteId === Craft::$app->getSites()->currentSite->id
+            && Craft::$app->getRequest()->getPathInfo() === $uri)
+        {
+            $element = Craft::$app->getUrlManager()->getMatchedElement();
+        }
+        if (!$element) {
+            $element = Craft::$app->getElements()->getElementByUri($uri, $siteId, $enabledOnly);
+        }
         if ($element && ($element->uri !== null)) {
             Seomatic::setMatchedElement($element);
         }


### PR DESCRIPTION
### Description

Try to use `UrlManager`s matched element if it matches what is being looked for in `MetaContainers::setMatchedElement()`. This prevents a number of duplicated queries on our more complex pages.