### PR TITLE
Fix incorrect references to `SeoEntry` in v4

### DIFF
--- a/src/seoelements/SeoCampaign.php
+++ b/src/seoelements/SeoCampaign.php
@@ -144,7 +144,7 @@ class SeoCampaign implements SeoElementInterface
                         );
                         // Create the meta bundles for this campaign type if it's new
                         if ($event->isNew) {
-                            SeoEntry::createContentMetaBundle($event->campaignType);
+                            SeoCampaign::createContentMetaBundle($event->campaignType);
                             Seomatic::$plugin->sitemaps->submitSitemapIndex();
                         }
                     }
@@ -167,7 +167,7 @@ class SeoCampaign implements SeoElementInterface
                         );
                         // Delete the meta bundles for this campaign type
                         Seomatic::$plugin->metaBundles->deleteMetaBundleBySourceId(
-                            SeoEntry::getMetaBundleType(),
+                            SeoCampaign::getMetaBundleType(),
                             $event->campaignType->id
                         );
                     }


### PR DESCRIPTION
This PR replaces copy-pasted references to `SeoEntry` with `SeoCampaign`, which was throwing an exception when creating new campaign types.