### PR TITLE
Remove `$debugModule` for performance tuning

### DIFF
--- a/src/services/MetaContainers.php
+++ b/src/services/MetaContainers.php
@@ -410,14 +410,13 @@ class MetaContainers extends Component
                 ],
             ]);
             $this->containerDependency = $dependency;
-            $debugModule = Craft::$app->getModule('debug');
-            if (Seomatic::$previewingMetaContainers || $debugModule) {
+            if (Seomatic::$previewingMetaContainers) {
                 Seomatic::$plugin->frontendTemplates->loadFrontendTemplateContainers($siteId);
                 $this->loadGlobalMetaContainers($siteId);
                 $this->loadContentMetaContainers();
                 $this->loadFieldMetaContainers();
                 // We only need the dynamic data for headless requests
-                if (Seomatic::$headlessRequest || Seomatic::$plugin->helper::isPreview() || $debugModule) {
+                if (Seomatic::$headlessRequest || Seomatic::$plugin->helper::isPreview()) {
                     DynamicMetaHelper::addDynamicMetaToContainers($uri, $siteId);
                 }
             } else {


### PR DESCRIPTION
When performance tuning it can be helpful to use the timeline view or the DB tab of the debug bar. Removing this code allows you to use the debug bar and get realistic numbers from the profiler.

I realize this is probably a breaking change, so if you'd rather I replace it with a config option or some other user-configurable heuristic, let me know and I can adjust the PR.