### PR TITLE
Creator id fix

### DIFF
--- a/src/seomatic-config/campaignmeta/Bundle.php
+++ b/src/seomatic-config/campaignmeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoCampaign;
  */
 
 return [
-    'bundleVersion' => '1.0.34',
+    'bundleVersion' => '1.0.35',
     'sourceBundleType' => SeoCampaign::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/campaignmeta/JsonLdContainer.php
+++ b/src/seomatic-config/campaignmeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',

--- a/src/seomatic-config/categorymeta/Bundle.php
+++ b/src/seomatic-config/categorymeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoCategory;
  */
 
 return [
-    'bundleVersion' => '1.0.27',
+    'bundleVersion' => '1.0.28',
     'sourceBundleType' => SeoCategory::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/categorymeta/JsonLdContainer.php
+++ b/src/seomatic-config/categorymeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',

--- a/src/seomatic-config/digitalproductmeta/Bundle.php
+++ b/src/seomatic-config/digitalproductmeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoDigitalProduct;
  */
 
 return [
-    'bundleVersion' => '1.0.35',
+    'bundleVersion' => '1.0.36',
     'sourceBundleType' => SeoDigitalProduct::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/digitalproductmeta/JsonLdContainer.php
+++ b/src/seomatic-config/digitalproductmeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',

--- a/src/seomatic-config/entrymeta/Bundle.php
+++ b/src/seomatic-config/entrymeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoEntry;
  */
 
 return [
-    'bundleVersion' => '1.0.30',
+    'bundleVersion' => '1.0.31',
     'sourceBundleType' => SeoEntry::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/entrymeta/JsonLdContainer.php
+++ b/src/seomatic-config/entrymeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',

--- a/src/seomatic-config/eventmeta/Bundle.php
+++ b/src/seomatic-config/eventmeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoEvent;
  */
 
 return [
-    'bundleVersion' => '1.0.2',
+    'bundleVersion' => '1.0.3',
     'sourceBundleType' => SeoEvent::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/eventmeta/JsonLdContainer.php
+++ b/src/seomatic-config/eventmeta/JsonLdContainer.php
@@ -49,7 +49,7 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'contributor' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'funder' => [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',

--- a/src/seomatic-config/productmeta/Bundle.php
+++ b/src/seomatic-config/productmeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoProduct;
  */
 
 return [
-    'bundleVersion' => '1.0.37',
+    'bundleVersion' => '1.0.38',
     'sourceBundleType' => SeoProduct::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/productmeta/JsonLdContainer.php
+++ b/src/seomatic-config/productmeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',

--- a/src/seomatic-config/shopifyproductmeta/Bundle.php
+++ b/src/seomatic-config/shopifyproductmeta/Bundle.php
@@ -19,7 +19,7 @@ use nystudio107\seomatic\seoelements\SeoShopifyProduct;
  */
 
 return [
-    'bundleVersion' => '1.0.38',
+    'bundleVersion' => '1.0.39',
     'sourceBundleType' => SeoShopifyProduct::getMetaBundleType(),
     'sourceId' => null,
     'sourceName' => null,

--- a/src/seomatic-config/shopifyproductmeta/JsonLdContainer.php
+++ b/src/seomatic-config/shopifyproductmeta/JsonLdContainer.php
@@ -47,10 +47,10 @@ return [
                     'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#identity',
                 ],
                 'creator' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'publisher' => [
-                    'id' => '{{ parseEnv(seomatic.site.identity.genericUrl) }}#creator',
+                    'id' => '{{ parseEnv(seomatic.site.creator.genericUrl) }}#creator',
                 ],
                 'image' => [
                     'type' => 'ImageObject',


### PR DESCRIPTION
### Description
When the creator url is different from the identity url, the references to the creator entity would be wrong.
Truncated example:
```json
{
      "@type": "WebSite",
      "author": {
        "@id": "https://example.com#identity"
      },
      "copyrightHolder": {
        "@id": "https://example.com#identity"
      },
      "creator": {
        "@id": "https://example.com#creator"
      },
      "publisher": {
        "@id": "https://example.com#creator"
      },
      "url": "https://example.com"
},
{
      "@id": "https://example.com#identity",
      "@type": "Organization",
      "name": "Example",
      "url": "https://example.com"
},
{
      "@id": "https://onstuimig.nl#creator",
      "@type": "Organization",
      "name": "Onstuimig",
      "url": "https://onstuimig.nl"
},
``` 

This PR makes sure all references to #creator use the creator url
