### PR TITLE
Make SEO preview sidebar UI more consistent with Craft

### DIFF
--- a/src/templates/_sidebars/_includes/sidebar-preview.twig
+++ b/src/templates/_sidebars/_includes/sidebar-preview.twig
@@ -10,39 +10,39 @@
 
 {% set displayPreviewInlineStyles = "border: none; padding-left: 0;" %}
 {% set previewTypes = previewTypes ?? seomatic.config.sidebarDisplayPreviewTypes ?? ['google', 'twitter', 'facebook'] %}
-<hr/>
-<div class="meta overflow-hidden">
-    <div class="data">
-        <h5 class="heading">{{ "SEO Preview:"|t('seomatic') }}</h5>
+
+<fieldset>
+    <legend class="h6">{{ "SEO Preview"|t('seomatic') }}</legend>
+    <div class="meta overflow-hidden">
+        <div style="zoom: 0.60; -moz-transform: scale(0.60); -moz-transform-origin: 0 0;">
+            {% if 'google' in previewTypes %}
+                {% include "seomatic/_includes/googlePreview.twig" %}
+            {% endif %}
+    
+            {% if 'twitter' in previewTypes %}
+                {% include "seomatic/_includes/twitterPreview.twig" %}
+            {% endif %}
+    
+            {% if 'facebook' in previewTypes %}
+                {% include "seomatic/_includes/facebookPreview.twig" %}
+            {% endif %}
+    
+            {% if 'linkedin' in previewTypes %}
+                {% include "seomatic/_includes/linkedinPreview.twig" %}
+            {% endif %}
+    
+            {% if 'pinterest' in previewTypes %}
+                {% include "seomatic/_includes/pinterestPreview.twig" %}
+            {% endif %}
+    
+            {% if 'slack' in previewTypes %}
+                {% include "seomatic/_includes/slackPreview.twig" %}
+            {% endif %}
+    
+            {% if 'discord' in previewTypes %}
+                {% include "seomatic/_includes/discordPreview.twig" %}
+            {% endif %}
+    
+        </div>
     </div>
-    <div style="zoom: 0.60; -moz-transform: scale(0.60); -moz-transform-origin: 0 0;">
-        {% if 'google' in previewTypes %}
-            {% include "seomatic/_includes/googlePreview.twig" %}
-        {% endif %}
-
-        {% if 'twitter' in previewTypes %}
-            {% include "seomatic/_includes/twitterPreview.twig" %}
-        {% endif %}
-
-        {% if 'facebook' in previewTypes %}
-            {% include "seomatic/_includes/facebookPreview.twig" %}
-        {% endif %}
-
-        {% if 'linkedin' in previewTypes %}
-            {% include "seomatic/_includes/linkedinPreview.twig" %}
-        {% endif %}
-
-        {% if 'pinterest' in previewTypes %}
-            {% include "seomatic/_includes/pinterestPreview.twig" %}
-        {% endif %}
-
-        {% if 'slack' in previewTypes %}
-            {% include "seomatic/_includes/slackPreview.twig" %}
-        {% endif %}
-
-        {% if 'discord' in previewTypes %}
-            {% include "seomatic/_includes/discordPreview.twig" %}
-        {% endif %}
-
-    </div>
-</div>
+</fieldset>

--- a/src/templates/settings/_includes/tab-facebook.twig
+++ b/src/templates/settings/_includes/tab-facebook.twig
@@ -3,7 +3,7 @@
 
 <fieldset>
     {% if field is not defined or 'seoPreview' in field.facebookEnabledFields %}
-        <h4 class="heading">{{ "SEO Preview:"|t('seomatic') }}</h4>
+        <h4 class="heading">{{ "SEO Preview"|t('seomatic') }}:</h4>
         {% include "seomatic/_includes/facebookPreview.twig" %}
     {% endif %}
 

--- a/src/templates/settings/_includes/tab-general.twig
+++ b/src/templates/settings/_includes/tab-general.twig
@@ -3,7 +3,7 @@
 
 <fieldset>
     {% if field is not defined or 'seoPreview' in field.generalEnabledFields %}
-        <h4 class="heading">{{ "SEO Preview:"|t('seomatic') }}</h4>
+        <h4 class="heading">{{ "SEO Preview"|t('seomatic') }}:</h4>
         {% include "seomatic/_includes/googlePreview.twig" %}
     {% endif %}
 

--- a/src/templates/settings/_includes/tab-twitter.twig
+++ b/src/templates/settings/_includes/tab-twitter.twig
@@ -3,7 +3,7 @@
 
 <fieldset>
     {% if field is not defined or 'seoPreview' in field.twitterEnabledFields %}
-        <h4 class="heading">{{ "SEO Preview:"|t('seomatic') }}</h4>
+        <h4 class="heading">{{ "SEO Preview"|t('seomatic') }}:</h4>
         {% include "seomatic/_includes/twitterPreview.twig" %}
     {% endif %}
 

--- a/src/translations/en/seomatic.php
+++ b/src/translations/en/seomatic.php
@@ -168,7 +168,6 @@ return [
     'From Asset Field' => 'From Asset Field',
     'Whether the `ads.txt` template should be rendered' => 'Whether the `ads.txt` template should be rendered',
     '#{varData.title}' => '#{varData.title}',
-    'SEO Preview' => 'SEO Preview',
     'Additional Sitemaps' => 'Additional Sitemaps',
     'Whether the URLs to files such as `.pdf`, `.xls`, `.doc` and other indexable file types in Asset fields or Asset fields in matrix blocks should be included in the sitemap' => 'Whether the URLs to files such as `.pdf`, `.xls`, `.doc` and other indexable file types in Asset fields or Asset fields in matrix blocks should be included in the sitemap',
     ' Settings' => ' Settings',

--- a/src/translations/en/seomatic.php
+++ b/src/translations/en/seomatic.php
@@ -168,7 +168,7 @@ return [
     'From Asset Field' => 'From Asset Field',
     'Whether the `ads.txt` template should be rendered' => 'Whether the `ads.txt` template should be rendered',
     '#{varData.title}' => '#{varData.title}',
-    'SEO Preview:' => 'SEO Preview:',
+    'SEO Preview' => 'SEO Preview',
     'Additional Sitemaps' => 'Additional Sitemaps',
     'Whether the URLs to files such as `.pdf`, `.xls`, `.doc` and other indexable file types in Asset fields or Asset fields in matrix blocks should be included in the sitemap' => 'Whether the URLs to files such as `.pdf`, `.xls`, `.doc` and other indexable file types in Asset fields or Asset fields in matrix blocks should be included in the sitemap',
     ' Settings' => ' Settings',


### PR DESCRIPTION
This PR makes the UI of the SEO preview sidebar pane on the element edit page more consistent with Craft and other plugins by moving the label and removing the line.

Before:

![screenshot-zvC16FqO@2x](https://github.com/user-attachments/assets/527674d7-9b24-45cd-aa5e-413c362ab880)

After:

![screenshot-yLPYMIsw@2x](https://github.com/user-attachments/assets/f0f2778b-9680-41da-9a86-fe2939a0376c)
