### PR TITLE
re #1560: Update preg_split in URLHelper

### DIFF
--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -287,7 +287,7 @@ class UrlHelper extends CraftUrlHelper
      */
     public static function encodeUrl(string $url): string
     {
-        $parts = preg_split('/([:\/?#\[\]@!$&\'()*+,;=%])/', $url, flags: PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('/([:\/?#\[\]@!$&\'()*+,;=%])/', $url, null, PREG_SPLIT_DELIM_CAPTURE);
         $url = '';
         foreach ($parts as $i => $part) {
             if ($i % 2 === 0) {


### PR DESCRIPTION
Version 3.9.10 contained php8 only code, so this will fix it for everyone still using PHP 7 - fixes #1560

### Description

See #1560 - new release causes a syntax error: 
```
ParseError
syntax error, unexpected ':', expecting ')'
```

### Related issues
#1560 