### PR TITLE
Adds sitemap enabled to Feed Me

### DIFF
--- a/src/templates/_includes/integrations/feedme/seo-settings.twig
+++ b/src/templates/_includes/integrations/feedme/seo-settings.twig
@@ -255,7 +255,12 @@ fields[seoMeta][metaGlobalVars][canonicalUrl]
 			label: 'Sitemap Enabled',
 			handle: 'sitemapUrls',
 			default: {
-				type: 'lightswitch',
+				type: 'select',
+				options: [
+					{ label: 'Don\'t import'|t('feed-me'), value: '' },
+					{ label: 'Enabled', value: '1' },
+					{ label: 'Disabled', value: '0' },
+				],
 			}
 		},
         {

--- a/src/templates/_includes/integrations/feedme/seo-settings.twig
+++ b/src/templates/_includes/integrations/feedme/seo-settings.twig
@@ -251,6 +251,13 @@ fields[seoMeta][metaGlobalVars][canonicalUrl]
     label: 'Sitemap',
     handle: 'metaSitemapVars',
     fields: [
+		{
+			label: 'Sitemap Enabled',
+			handle: 'sitemapUrls',
+			default: {
+				type: 'lightswitch',
+			}
+		},
         {
             label: 'Change Frequency',
             handle: 'sitemapChangeFreq',


### PR DESCRIPTION
### Description
This PR adds the field for "Sitemap Enabled" in feedme.

### Caveat
This PR only adds the field, but it doesn't allow it yet to be imported. That still gets blocked by the "override" option. 
For the robots field, it just worked out of the box, so I compared the processing of those two and found this to be the difference:

In [Sitemap.php](https://github.com/nystudio107/craft-seomatic/blob/develop-v5/src/helpers/Sitemap.php#L593) in processing the `metaSiteMapVars` the inherited are removed.
```
$attributes = $fieldMetaBundle->metaSitemapVars->getAttributes();
$inherited = array_keys(ArrayHelper::remove($attributes, 'inherited', []));
$attributes = array_intersect_key($attributes, array_flip((array)$seoSettingsField->sitemapEnabledFields));
$attributes = array_filter($attributes, [ArrayHelper::class, 'preserveBools']);
foreach ($inherited as $inheritedAttribute) {
    unset($attributes[$inheritedAttribute]);
}
$metaBundle->metaSitemapVars->setAttributes($attributes, false);
```

But in later in [Sitemap.php](https://github.com/nystudio107/craft-seomatic/blob/develop-v5/src/helpers/Sitemap.php#L611) in processing the `metaGlobalVars` they aren't.

```
$attributes = $fieldMetaBundle->metaGlobalVars->getAttributes();
$attributes = array_filter(
    $attributes,
    [ArrayHelper::class, 'preserveBools']
);
$metaBundle->metaGlobalVars->setAttributes($attributes, false);
```

#### Solution
The solution is more a business decision on the plugin part where to solve this: in the processing part or in feed-me.
Also I couldn't yet estimate the impact on our code so for a quick-fix, I added the Override field as well and that works.
```
		{
			label: 'Override Sitemap Enabled',
			handle: 'override-sitemapUrls',
			default: {
				type: 'select',
				options: [
					{ label: 'Don\'t import'|t('feed-me'), value: '' },
					{ label: 'Override (use imported value)', value: '1' },
					{ label: 'Inherit (ignore imported value)', value: '0' },
				],
			}
		},
```

### Related issues
A request for this feature already existed in: https://github.com/nystudio107/craft-seomatic/issues/1070 
